### PR TITLE
Add example names to title

### DIFF
--- a/examples/basic/templates/index.html
+++ b/examples/basic/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - basic</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/basic/templates/index.html
+++ b/examples/basic/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - basic</title>
+  <title>Flask-Dropzone Demo: Basic</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/click-upload/templates/index.html
+++ b/examples/click-upload/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Flask-Dropzone Demo - click-upload</title>
+    <title>Flask-Dropzone Demo: Click Upload</title>
     {{ dropzone.load_css() }}
     {{ dropzone.style('border: 2px dashed #0087F7; margin: 10px 0 10px; min-height: 400px;') }}
 </head>

--- a/examples/click-upload/templates/index.html
+++ b/examples/click-upload/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Flask-Dropzone Demo</title>
+    <title>Flask-Dropzone Demo - click-upload</title>
     {{ dropzone.load_css() }}
     {{ dropzone.style('border: 2px dashed #0087F7; margin: 10px 0 10px; min-height: 400px;') }}
 </head>

--- a/examples/complete-redirect/templates/index.html
+++ b/examples/complete-redirect/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - complete-redirect</title>
+  <title>Flask-Dropzone Demo: Complete Redirect</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/complete-redirect/templates/index.html
+++ b/examples/complete-redirect/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - complete-redirect</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/csrf/templates/index.html
+++ b/examples/csrf/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - csrf</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/csrf/templates/index.html
+++ b/examples/csrf/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - csrf</title>
+  <title>Flask-Dropzone Demo: CSRF</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/custom-options/templates/index.html
+++ b/examples/custom-options/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - custom-options</title>
+  <title>Flask-Dropzone Demo: Custom Options</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/custom-options/templates/index.html
+++ b/examples/custom-options/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - custom-options</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/in-form/templates/index.html
+++ b/examples/in-form/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Flask-Dropzone Demo</title>
+    <title>Flask-Dropzone Demo - in-form</title>
     {{ dropzone.load_css() }}
     {{ dropzone.style('border: 2px dashed #0087F7; margin: 10px 0 10px; min-height: 400px; width: 800px') }}
 </head>

--- a/examples/in-form/templates/index.html
+++ b/examples/in-form/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Flask-Dropzone Demo - in-form</title>
+    <title>Flask-Dropzone Demo: In Form</title>
     {{ dropzone.load_css() }}
     {{ dropzone.style('border: 2px dashed #0087F7; margin: 10px 0 10px; min-height: 400px; width: 800px') }}
 </head>

--- a/examples/large-file/templates/index.html
+++ b/examples/large-file/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - large-file</title>
+  <title>Flask-Dropzone Demo: Large File</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/large-file/templates/index.html
+++ b/examples/large-file/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - large-file</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/parallel-upload/templates/index.html
+++ b/examples/parallel-upload/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo</title>
+  <title>Flask-Dropzone Demo - parallel-upload</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>

--- a/examples/parallel-upload/templates/index.html
+++ b/examples/parallel-upload/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Flask-Dropzone Demo - parallel-upload</title>
+  <title>Flask-Dropzone Demo: Parallel Upload</title>
   {{ dropzone.load_css() }}
   {{ dropzone.style('border: 2px dashed #0087F7; margin: 10%; min-height: 400px;') }}
 </head>


### PR DESCRIPTION
For better distinguishing examples when running in browser, since some of the UIs look exactly the same.