### PR TITLE
Feature + documentation: Content Security Policy and CSRF token

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -101,7 +101,7 @@ If you like to use your web application under a strict `Content Security Policy 
     default_http_header = {'Content-Security-Policy' :
       f"default-src 'self'; script-src 'self' 'nonce-{nonce}'"
     
-    nonce = str(base64.b64encode(os.urandom(64)))
+    nonce = base64.b64encode(os.urandom(64)).decode('utf8')
     render_template('template.tmpl', nonce = nonce), 200, default_http_header
 
 		

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -88,6 +88,27 @@ Try the demo application in ``examples/csrf`` and see `CSRFProtect's
 documentation <http://flask-wtf.readthedocs.io/en/latest/csrf.html>`__
 for more details.
 
+Content Security Policy
+-----------------------
+
+If you like to use your web application under a strict `Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>`__ (CSP), just embedding JavaScript code via ``{{ dropzone.config() }}`` into a template will not work. You could move the configuration code into a separate JavaScript file and reference this resource from your HTML page. However, when you like to enable a CSRF protection as well, you need to handle the CSRF token and the CSP nonce value. The simple solution is to embedd the configuration code into the HTML page and pass a ``nonce`` value for CSP as shown below:
+
+.. code-block:: python
+
+    import base64
+    import os
+    
+    default_http_header = {'Content-Security-Policy' :
+      f"default-src 'self'; script-src 'self' 'nonce-{nonce}'"
+    
+    nonce = str(base64.b64encode(os.urandom(64)))
+    render_template('template.tmpl', nonce = nonce), 200, default_http_header
+
+		
+.. code-block:: jinja
+
+    {{ dropzone.config(nonce=nonce) }}
+		
 Server Side Validation
 ----------------------
 

--- a/flask_dropzone/__init__.py
+++ b/flask_dropzone/__init__.py
@@ -178,7 +178,7 @@ Dropzone.options.myDropzone = {
         return Markup(js)
 
     @staticmethod
-    def config(redirect_url=None, custom_init='', custom_options='', **kwargs):
+    def config(redirect_url=None, custom_init='', custom_options='', nonce=None, **kwargs):
         """Initialize dropzone configuration.
 
         .. versionadded:: 1.4.4
@@ -186,6 +186,7 @@ Dropzone.options.myDropzone = {
         :param redirect_url: The URL to redirect when upload complete.
         :param custom_init: Custom javascript code in ``init: function() {}``.
         :param custom_options: Custom javascript code in ``Dropzone.options.myDropzone = {}``.
+        :param nonce: Pass a nonce value that is newhen embedding the JavaScript code into a Content Security Policy protected web page.
         :param **kwargs: Mirror configuration variable, lowercase and without prefix.
                          For example, ``DROPZONE_UPLOAD_MULTIPLE`` becomes ``upload_multiple`` here.
         """
@@ -293,7 +294,12 @@ Dropzone.options.myDropzone = {
             csrf_token = render_template_string('{{ csrf_token() }}')
             custom_options += 'headers: {"X-CSRF-Token": "%s"},' % csrf_token
 
-        return Markup('''<script>
+        if nonce:
+            nonce_html = " nonce=\"%s\"" % nonce
+        else:
+            nonce_html = ""
+            
+        return Markup('''<script%s>
         Dropzone.options.myDropzone = {
           init: function() {
               %s  // redirect after queue complete
@@ -320,7 +326,7 @@ Dropzone.options.myDropzone = {
           %s  // custom options code
         };
         </script>
-                ''' % (redirect_js, click_listener, custom_init, click_option,
+                ''' % (nonce_html, redirect_js, click_listener, custom_init, click_option,
                        upload_multiple, parallel_uploads, param, size, allowed_type, max_files,
                        default_message, browser_unsupported, invalid_file_type, file_too_big,
                        server_error, max_files_exceeded, cancelUpload, removeFile, cancelConfirmation,


### PR DESCRIPTION
I worked on an existing application and fitted a CSP and CSRF afterwards. I thought about and tried different approaches and in the end, the simplest way was to just pass another parameter to configure. I made a pull request from my changes. Maybe it is useful to someone.