### PR TITLE
Use Markup from MarkupSafe due to deprecation in Flask 2.4

### DIFF
--- a/flask_dropzone/__init__.py
+++ b/flask_dropzone/__init__.py
@@ -8,7 +8,8 @@
     :license: MIT, see LICENSE for more details.
 """
 import warnings
-from flask import Blueprint, current_app, url_for, Markup, render_template_string
+from flask import Blueprint, current_app, url_for, render_template_string
+from markupsafe import Markup
 
 from .utils import random_filename, get_url  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'Flask'
+        'Flask', 
+        'MarkupSafe'
     ],
     keywords='flask extension development upload',
     classifiers=[


### PR DESCRIPTION
We get a ton of warnings in our CI at my $job. In Flask 2.3 [`Markup`](https://github.com/pallets/flask/pull/4996) was deprecated and will be removed in Flask 2.4, this fixes it by using `MarkupSafe` directly.